### PR TITLE
gh: automate semver tags

### DIFF
--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -1,0 +1,13 @@
+name: Update Semver
+on:
+  push:
+    branches-ignore:
+      - '**'
+    tags:
+      - 'v*.*.*'
+jobs:
+  update-semver:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: haya14busa/action-update-semver@v1


### PR DESCRIPTION
When `v1.2.3` is published, automatically force-push tags `v1` and `v1.2` to point to the same ref.