### PR TITLE
Fix rendering of non-string attribute values

### DIFF
--- a/internal/action/markdown.go
+++ b/internal/action/markdown.go
@@ -78,5 +78,5 @@ func ValueToMarkdown(value interface{}) string {
 		return "_unknown_"
 	}
 
-	return fmt.Sprintf("%s", value)
+	return fmt.Sprintf("%v", value)
 }

--- a/internal/action/markdown.go
+++ b/internal/action/markdown.go
@@ -53,17 +53,7 @@ func tableRow(dir string, resource TerraformResourceType, data *ResourceRow) ([]
 
 	for _, key := range resource.Attributes {
 		value := data.Attributes[key]
-
-		var cell string
-		if value == nil {
-			cell = ""
-		} else if _, ok := value.(*terraform.UnknownAttributeValue); ok {
-			cell = "_unknown_"
-		} else {
-			cell = fmt.Sprintf("%s", value)
-		}
-
-		row = append(row, cell)
+		row = append(row, ValueToMarkdown(value))
 	}
 
 	return row, nil
@@ -77,4 +67,16 @@ func tableHeaders(attributes []string) []string {
 	}
 
 	return headers
+}
+
+func ValueToMarkdown(value interface{}) string {
+	if value == nil {
+		return ""
+	}
+
+	if _, ok := value.(*terraform.UnknownAttributeValue); ok {
+		return "_unknown_"
+	}
+
+	return fmt.Sprintf("%s", value)
 }

--- a/internal/action/markdown_test.go
+++ b/internal/action/markdown_test.go
@@ -1,0 +1,54 @@
+package action
+
+import (
+	"testing"
+
+	"github.com/observeinc/terraform-resource-markdown-table-action/internal/terraform"
+)
+
+func TestValueToMarkdown(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value interface{}
+		want  string
+	}{
+		{
+			name:  "string",
+			value: "foo",
+			want:  "foo",
+		},
+		{
+			name:  "int",
+			value: 1,
+			want:  "1",
+		},
+		{
+			name:  "float",
+			value: 1.1,
+			want:  "1.1",
+		},
+		{
+			name:  "bool",
+			value: true,
+			want:  "true",
+		},
+		{
+			name:  "unknown",
+			value: &terraform.UnknownAttributeValue{},
+			want:  "_unknown_",
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := ValueToMarkdown(tc.value); got != tc.want {
+				t.Errorf("ValueToMarkdown() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Number and boolean attributes were being rendered with surrounding type information. This fixes the output and extracts the behavior to a unit-tested `ValueToMarkdown()` function.

Closes #5 