### PR TITLE
terraform: sort resources by name

### DIFF
--- a/internal/terraform/parser.go
+++ b/internal/terraform/parser.go
@@ -3,6 +3,7 @@ package terraform
 import (
 	"fmt"
 	"path/filepath"
+	"sort"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclparse"
@@ -93,12 +94,20 @@ func (p *Parser) RequiredProviderSource(name string) (tfaddr.Provider, error) {
 	return tfaddr.MustParseProviderSource(rp.Source), nil
 }
 
-func (p *Parser) ResourcesOfType(resourceType string) (resources []*tfconfig.Resource) {
+// ResourcesOfType returns all resources of the given type defined in the module.
+// Resources are sorted lexicographically by name, to ensure stable order.
+func (p *Parser) ResourcesOfType(resourceType string) []*tfconfig.Resource {
+	resources := []*tfconfig.Resource{}
+
 	for _, resource := range p.module.ManagedResources {
 		if resource.Type == resourceType {
 			resources = append(resources, resource)
 		}
 	}
+
+	sort.Slice(resources, func(i, j int) bool {
+		return resources[i].Name < resources[j].Name
+	})
 
 	return resources
 }

--- a/internal/terraform/parser_test.go
+++ b/internal/terraform/parser_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/hashicorp/terraform-config-inspect/tfconfig"
 	tfjson "github.com/hashicorp/terraform-json"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -207,6 +208,136 @@ terraform {
 
 			if diff := cmp.Diff(got, tc.want, cmpopts.IgnoreFields(UnknownAttributeValue{}, "Expr")); diff != "" {
 				t.Errorf("unexpected attributes -want +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestParser_ResourcesOfType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		config       string
+		resourceType string
+		want         []*tfconfig.Resource
+	}{
+		{
+			name: "one",
+			config: `
+resource "test_resource_a" "test" {}
+`,
+			resourceType: "test_resource_a",
+			want: []*tfconfig.Resource{
+				{
+					Type: "test_resource_a",
+					Name: "test",
+				},
+			},
+		},
+		{
+			name:         "empty",
+			resourceType: "test_resource_a",
+			want:         []*tfconfig.Resource{},
+		},
+		{
+			name: "ignore other types",
+			config: `
+resource "test_resource_a" "test" {}
+resource "test_resource_b" "test" {}
+`,
+			resourceType: "test_resource_a",
+			want: []*tfconfig.Resource{
+				{
+					Type: "test_resource_a",
+					Name: "test",
+				},
+			},
+		},
+		{
+			name: "sort resources by name",
+			config: `
+resource "test_resource_a" "c" {}
+resource "test_resource_a" "b" {}
+resource "test_resource_a" "a" {}
+`,
+			resourceType: "test_resource_a",
+			want: []*tfconfig.Resource{
+				{
+					Type: "test_resource_a",
+					Name: "a",
+				},
+				{
+					Type: "test_resource_a",
+					Name: "b",
+				},
+				{
+					Type: "test_resource_a",
+					Name: "c",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			parser, err := NewParser(&tfjson.ProviderSchemas{
+				Schemas: map[string]*tfjson.ProviderSchema{
+					"registry.terraform.io/test/test": {
+						ResourceSchemas: map[string]*tfjson.Schema{
+							"test_resource_a": {
+								Block: &tfjson.SchemaBlock{
+									Attributes: map[string]*tfjson.SchemaAttribute{
+										"foo": {
+											AttributeType: cty.Bool,
+										},
+									},
+								},
+							},
+							"test_resource_b": {
+								Block: &tfjson.SchemaBlock{
+									Attributes: map[string]*tfjson.SchemaAttribute{
+										"foo": {
+											AttributeType: cty.Bool,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			})
+
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			dir, err := os.MkdirTemp("", "test")
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { os.RemoveAll(dir) })
+
+			if err := os.WriteFile(filepath.Join(dir, "main.tf"), []byte(tc.config), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := parser.LoadModule(dir); err != nil {
+				t.Fatal(err)
+			}
+
+			got := parser.ResourcesOfType(tc.resourceType)
+
+			opts := cmp.Options{
+				cmpopts.IgnoreFields(tfconfig.Resource{}, "Provider", "Pos", "Mode"),
+			}
+
+			if diff := cmp.Diff(got, tc.want, opts); diff != "" {
+				t.Errorf("unexpected resources -want +got:\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Sorts resources alphabetically to ensure a stable order. Previously, resources were printed in an unstable order, resulting in perpetual diffs.

Closes #8