### PR TITLE
Fix replacement in existing fences

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
         test:
           - simple
           - existing
+          - replace
     steps:
       - uses: actions/checkout@v3
       - uses: ./

--- a/internal/action/run.go
+++ b/internal/action/run.go
@@ -132,6 +132,8 @@ func Run(ctx context.Context, inputs Inputs) error {
 	return writeBytes(
 		file,
 		existing[:start],
+		[]byte(BeforeComment),
+		newline,
 		buffer.Bytes(),
 		newline,
 		existing[end:],

--- a/internal/action/run.go
+++ b/internal/action/run.go
@@ -132,7 +132,6 @@ func Run(ctx context.Context, inputs Inputs) error {
 	return writeBytes(
 		file,
 		existing[:start],
-		newline,
 		buffer.Bytes(),
 		newline,
 		existing[end:],

--- a/internal/action/run.go
+++ b/internal/action/run.go
@@ -132,6 +132,7 @@ func Run(ctx context.Context, inputs Inputs) error {
 	return writeBytes(
 		file,
 		existing[:start],
+		newline,
 		buffer.Bytes(),
 		newline,
 		existing[end:],

--- a/testdata/replace/expected.md
+++ b/testdata/replace/expected.md
@@ -1,0 +1,12 @@
+I am existing leading content
+
+<!-- BEGIN_TF_RESOURCE_TABLES -->
+## observe_monitor
+
+|      **Name**       | `name` | `description` |
+|---------------------|--------|---------------|
+| [`foo`](main.tf#L1) | Foo    | Bar           |
+
+<!-- END_TF_RESOURCE_TABLES -->
+
+I am existing trailing content

--- a/testdata/replace/main.tf
+++ b/testdata/replace/main.tf
@@ -1,0 +1,10 @@
+resource "observe_monitor" "foo" {
+  name = "Foo"
+  description = "Bar"
+
+  workspace = var.workspace.oid
+  
+  inputs = {
+    "key" = "value"
+  }
+}

--- a/testdata/replace/output.md
+++ b/testdata/replace/output.md
@@ -1,6 +1,7 @@
 I am existing leading content
 
 <!-- BEGIN_TF_RESOURCE_TABLES -->
+This is placeholder content. It will be replaced by the resource table since it's inside the comment fences.
 <!-- END_TF_RESOURCE_TABLES -->
 
 I am existing trailing content

--- a/testdata/replace/output.md
+++ b/testdata/replace/output.md
@@ -1,0 +1,6 @@
+I am existing leading content
+
+<!-- BEGIN_TF_RESOURCE_TABLES -->
+<!-- END_TF_RESOURCE_TABLES -->
+
+I am existing trailing content

--- a/testdata/replace/variables.tf
+++ b/testdata/replace/variables.tf
@@ -1,0 +1,5 @@
+variable "workspace" {
+  type = object({
+    oid = string
+  })
+}

--- a/testdata/replace/versions.tf
+++ b/testdata/replace/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    observe = {
+      source = "terraform.observeinc.com/observeinc/observe"
+    }
+  }
+}


### PR DESCRIPTION
Tests replacement of content within existing comment fences and fixes a bug where the before comment was not included after replacement. To simplify the test, the existing fences have placeholder content. Normally, they'd have an existing markdown table, but the action should replace any content inside the fences with freshly generated output.