### PR TITLE
Allow header level to be set via `resource_header_level`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,9 @@ inputs:
       A YAML-encoded list of resources.
       Each resource must have a `name` and a list of `attributes` that will be included in the table.
     required: true
+  resource_header_level:
+    description: The markdown header level that will be used for each resource
+    default: '2'
 outputs:
   markdown:
     description: The rendered markdown output

--- a/internal/action/inputs.go
+++ b/internal/action/inputs.go
@@ -13,6 +13,7 @@ type Inputs struct {
 	WorkingDirectory string
 	ResourceTypes    ResourcesInput
 	OutputFile       string
+	HeaderLevel      int
 }
 
 type ResourcesInput string

--- a/internal/action/markdown.go
+++ b/internal/action/markdown.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"strings"
 
 	"github.com/hashicorp/terraform-config-inspect/tfconfig"
 	"github.com/observeinc/terraform-resource-markdown-table-action/internal/terraform"
@@ -16,8 +17,8 @@ type ResourceRow struct {
 	Attributes map[string]interface{}
 }
 
-func WriteMarkdown(dir string, resource TerraformResourceType, rows []*ResourceRow, writer io.Writer) error {
-	if _, err := writer.Write([]byte(fmt.Sprintf("## %s\n\n", resource.Name))); err != nil {
+func WriteMarkdown(dir string, resource TerraformResourceType, rows []*ResourceRow, headerLevel int, writer io.Writer) error {
+	if _, err := writer.Write([]byte(fmt.Sprintf("%s %s\n\n", strings.Repeat("#", headerLevel), resource.Name))); err != nil {
 		return err
 	}
 

--- a/internal/action/run.go
+++ b/internal/action/run.go
@@ -75,7 +75,7 @@ func Run(ctx context.Context, inputs Inputs) error {
 			rows = append(rows, row)
 		}
 
-		if err := WriteMarkdown(inputs.WorkingDirectory, *resourceType, rows, &buffer); err != nil {
+		if err := WriteMarkdown(inputs.WorkingDirectory, *resourceType, rows, inputs.HeaderLevel, &buffer); err != nil {
 			return fmt.Errorf("failed to write markdown: %w", err)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -2,19 +2,36 @@ package main
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/observeinc/terraform-resource-markdown-table-action/internal/action"
 	"github.com/sethvargo/go-githubactions"
 )
+
+const defaultHeaderLevel = 2
 
 func main() {
 	inputs := action.Inputs{
 		WorkingDirectory: githubactions.GetInput("working_directory"),
 		OutputFile:       githubactions.GetInput("output_file"),
 		ResourceTypes:    action.ResourcesInput(githubactions.GetInput("resources")),
+		HeaderLevel:      headerLevelFromInput(githubactions.GetInput("resource_header_level")),
 	}
 
 	if err := action.Run(context.Background(), inputs); err != nil {
 		githubactions.Fatalf("%v", err)
 	}
+}
+
+func headerLevelFromInput(input string) int {
+	if input == "" {
+		return defaultHeaderLevel
+	}
+
+	i, err := strconv.Atoi(input)
+	if err != nil {
+		githubactions.Fatalf("failed to parse resource_header_level: %v", err)
+	}
+
+	return i
 }


### PR DESCRIPTION
Currently, all resource headers are `<h2>` (`##`). This allows callers to customize that. To use an `<h3>`:

```yaml
with:
  resource_header_level: 3
```

The action will validate the input and fail if a non-integer is supplied.

Closes #6